### PR TITLE
16 Add a line to reference where the block will be positioned

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,3 @@
-.ce-block--drop-target .ce-block__content{
-  outline-color: #a0a0a0;
-  outline-style: dashed;
-  outline-width: 1px;
-}
-
 .ce-block--drop-target .ce-block__content:before {
   content: "";
   position: absolute;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,35 @@ export default class DragDrop {
       settingsButton.addEventListener('dragstart', () => {
         this.startBlock = this.api.getCurrentBlockIndex();
       });
+      settingsButton.addEventListener('drag', () => {
+        const allBlocks = this.holder.querySelectorAll('.ce-block');
+        const blockFocused = this.holder.querySelector('.ce-block--drop-target');
+        this.setBorderBlocks(allBlocks, blockFocused);
+      });
     }
+  }
+  /**
+   * Sets dinamically the borders in the blocks when a block is dragged
+   * @param {object} allBlocks Contains all the blocks in the holder
+   * @param {HTMLElement} blockFocused Is the element where the dragged element will be dropped.
+   */
+
+  setBorderBlocks(allBlocks, blockFocused) {
+    const borderStyle = '1px dashed #aaa';
+    Object.values(allBlocks).forEach((block) => {
+      const blockContent = block.querySelector('.ce-block__content');
+      if (block !== blockFocused) {
+        blockContent.style.removeProperty('border-top');
+        blockContent.style.removeProperty('border-bottom');
+      } else {
+        const index = Object.keys(allBlocks).find((key) => allBlocks[key] === blockFocused);
+        if (index > this.startBlock) {
+          blockContent.style.borderBottom = borderStyle;
+        } else {
+          blockContent.style.borderTop = borderStyle;
+        }
+      }
+    });
   }
 
   /**
@@ -51,6 +79,9 @@ export default class DragDrop {
       if (this.holder.contains(target)) {
         const dropTarget = this.getDropTarget(target);
         if (dropTarget) {
+          const blockContent = dropTarget.querySelector('.ce-block__content');
+          blockContent.style.removeProperty('border-top');
+          blockContent.style.removeProperty('border-bottom');
           this.endBlock = this.getTargetPosition(dropTarget);
           this.moveBlocks();
         }

--- a/test/dragDrop.test.js
+++ b/test/dragDrop.test.js
@@ -6,7 +6,8 @@ import editor from './fixtures/editor';
 
 describe('DragDrop', () => {
   const content = '<div id="editorjs">'
-  + '<div id="first" class="ce-block"> First </div> <div id="second" class="ce-block"> Second </div>'
+  + '<div id="first" class="ce-block"><div class="ce-block__content"> First </div></div>'
+  + '<div id="second" class="ce-block"><div class="ce-block__content"> Second </div></div>'
   + '<div class="ce-toolbar__settings-btn">Drag</div></div>';
   document.body.innerHTML = content;
 


### PR DESCRIPTION
Main issue: 
When a block is dragged, a top-border and a bottom-border is sets in the position where the block will be positioned. The idea is to set a line where the block will be positioned to reference better the position. 

Solution:
Set a dynamical border to reference the position where the block will be.  Also, the test was updated. 

Fix #16   