### PR TITLE
Keep read-only permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   test:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -28,6 +25,6 @@ jobs:
       - run: yarn
       - run: yarn test --coverage
       - name: Coveralls
-        uses: coverallsapp/github-action@3284643be2c47fb6432518ecec17f1255e8a06a6
+        uses: coverallsapp/github-action@3284643be2c47fb6432518ecec17f1255e8a06a6 # master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Keep read-only permissions in CI workflow

https://api.securityscorecards.dev/projects/github.com/kommitters/editorjs-drag-drop

![image](https://user-images.githubusercontent.com/39246879/209726141-3d5821f2-35a7-4e8c-94fd-f24777f00864.png)
