### PR TITLE
Prepare release v1.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.13 (13.01.2023)
+
+* Block egress traffic in GitHub Actions.
+* Add stability badge in README.
+
 ## 1.1.12 (27.12.2022)
 
 * Add Renovate as dependency update tool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.13 (13.01.2023)
 
+* Update all dependencies.
 * Block egress traffic in GitHub Actions.
 * Add stability badge in README.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-drag-drop",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "keywords": [
     "drag",
     "drop",


### PR DESCRIPTION
## 1.1.13 (13.01.2023)

* Block egress traffic in GitHub Actions.
* Add stability badge in README.