### PR TITLE
Ensure setAttribute fires after editor is ready

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,14 +57,36 @@ export default class DragDrop {
   setDragListener() {
     if (!this.readOnly) {
       const settingsButton = this.holder.querySelector('.ce-toolbar__settings-btn');
+      if (settingsButton) {
+        this.initializeDragListener(settingsButton);
+      } else {
+        // If there's no settings button, we wait for it to be added to the DOM
+        const observer = new MutationObserver((mutations, obs) => {
+          const settingsButton = this.holder.querySelector(
+            ".ce-toolbar__settings-btn"
+          );
+          if (settingsButton) {
+            this.initializeDragListener(settingsButton);
+            obs.disconnect();
+          }
+        });
 
-      settingsButton.setAttribute('draggable', 'true');
-      settingsButton.addEventListener('dragstart', () => {
-        this.startBlock = this.api.getCurrentBlockIndex();
-      });
+        observer.observe(this.holder, {
+          childList: true,
+          subtree: true,
+        });
+      }
+    }
+  }
+
+  initializeDragListener(settingsButton) {
+    settingsButton.setAttribute("draggable", "true");
+    settingsButton.addEventListener("dragstart", () => {
+      this.startBlock = this.api.getCurrentBlockIndex();
+    });
       settingsButton.addEventListener('drag', () => {
-        this.toolbar.close(); // this closes the toolbar when we start the drag
-        if (!this.isTheOnlyBlock()) {
+      this.toolbar.close(); // this closes the toolbar when we start the drag
+      if (!this.isTheOnlyBlock()) {
           const allBlocks = this.holder.querySelectorAll('.ce-block');
           const blockFocused = this.holder.querySelector('.ce-block--drop-target');
           this.setElementCursor(blockFocused);
@@ -72,7 +94,7 @@ export default class DragDrop {
         }
       });
     }
-  }
+     
   /**
    * Sets dinamically the borders in the blocks when a block is dragged
    * @param {object} allBlocks Contains all the blocks in the holder


### PR DESCRIPTION
Fixed issue #148 by ensuring that setAttribute is called only after the editor DOM elements are fully loaded, preventing errors caused by accessing elements that are not yet available.

closes #148 